### PR TITLE
repositioned HBM pop out

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -260,7 +260,7 @@
     cursor: pointer;
     padding: 5px;
     position: absolute;
-    right: 180px;
+    right: 185px;
   }
   .hamburger ul {
     list-style: none;
@@ -273,6 +273,7 @@
     border: 3px solid black;
     border-radius: 15px;
     text-decoration-color: white;
+    margin: 1px;
 }
   
 


### PR DESCRIPTION
Moved the pop out from the HBM slightly so it wasn't right against the side of the screen and created a margin between the buttons so the borders weren't overlapping.