### PR TITLE
gap between header and pop out menu

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -262,6 +262,7 @@
     padding: 5px;
     position: absolute;
     right: 185px;
+    top: 63px;
   }
   .hamburger ul {
     list-style: none;


### PR DESCRIPTION
added a 1px gap between the header component and HBM pop out to make it more uniformed like the rest of the pop menu as it was overlapping onto the header before