### PR TITLE
readded sound effect to player hand

### DIFF
--- a/client/src/components/SoloGame.tsx
+++ b/client/src/components/SoloGame.tsx
@@ -313,6 +313,8 @@ function SoloGame(): JSX.Element {
   function moveCard(card: JSX.Element, index: number) {
     // if no cards have been played yet this turn, play a card
     if (!player.playedCardThisTurn) {
+      const audio = new Audio(cardflip);
+      audio.play();
       player.hand.splice(index, 1);
       setPlayer({
         ...player,


### PR DESCRIPTION
The card flip noise has been readded to play from a players deck hand, due to the new code it now plays when a card can be played and doesn't when a card cannot be played